### PR TITLE
Demo filter improvements

### DIFF
--- a/src/test/resources/META-INF/resources/frontend/fc-font-awesome-gallery.ts
+++ b/src/test/resources/META-INF/resources/frontend/fc-font-awesome-gallery.ts
@@ -87,9 +87,8 @@ class FontAwesomeGalleryDemo extends LitElement {
   }
   
   __testFilterString(icon: String) {
-	if (!this.filterString) return true;
-	if (this.filterString.includes('-')) return icon.includes(this.filterString);
-	return  icon.split('-').some(word=>word.startsWith(this.filterString));
+	const matches = (s:string) => s.includes('-') ? icon.includes(s) : icon.split('-').some(word=>word.startsWith(s));
+	return !this.filterString || this.filterString.split(' ').filter(s=>s).every(matches);
   }
   
   __handleClick(detail: String) {

--- a/src/test/resources/META-INF/resources/frontend/fc-font-awesome-gallery.ts
+++ b/src/test/resources/META-INF/resources/frontend/fc-font-awesome-gallery.ts
@@ -88,7 +88,7 @@ class FontAwesomeGalleryDemo extends LitElement {
   
   __testFilterString(icon: String) {
 	const matches = (s:string) => s.includes('-') ? icon.includes(s) : icon.split('-').some(word=>word.startsWith(s));
-	return !this.filterString || this.filterString.split(' ').filter(s=>s).every(matches);
+	return !this.filterString || this.filterString.split(' ').filter(s=>s).every(s => s[0]=='!' ? (s=s.substring(1), !(s &&matches(s))): matches(s));
   }
   
   __handleClick(detail: String) {


### PR DESCRIPTION
Improve the filter so that space works as AND operator and `!` works as NOT operator.

Thus if you write `arrow down` it will match:

```
arrow-alt-circle-down
arrow-circle-down
arrow-down
arrow-down-1-9
arrow-down-9-1
arrow-down-a-z
arrow-down-long
arrow-down-short-wide
arrow-down-up-across-line
arrow-down-up-lock
arrow-down-wide-short
arrow-down-z-a
arrow-trend-down
arrow-turn-down
arrows-down-to-line
arrows-down-to-people
arrows-up-down
arrows-up-down-left-right
cart-arrow-down
circle-arrow-down
cloud-arrow-down
file-arrow-down
long-arrow-alt-down
long-arrow-down
person-arrow-down-to-line
temperature-arrow-down
tent-arrow-down-to-line
tent-arrows-down
```

The latter two results can be excluded by writting  `arrow down !tent`