### PR TITLE
docs: document supported version range

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Integration of FontAwesome and vaadin-icon for Vaadin 10+
 ## Versions
 
 - **Version 1.0.4** (based on FontAwesome 5.11.2) is compatible with Vaadin 10-13 and Vaadin 14 in bower mode. 
-- **Version 2.2.2** (based on FontAwesome 5.15.4) is compatible with Vaadin 14+ in npm mode.
-- **Version 3.0.x** (based on the latest version of FontAwesome 6, using polymer `iron-icon`) is compatible with Vaadin 14+ in npm mode.
+- **Version 2.2.2** (based on FontAwesome 5.15.4) is compatible with Vaadin 14-23 in npm mode.
+- **Version 3.0.x** (based on the latest version of FontAwesome 6, using polymer `iron-icon`) is compatible with Vaadin 14-23 in npm mode.
 - **Version 4.1.x** (based on the latest version of FontAwesome 6, using `vaadin-icon`) is compatible with Vaadin 23.
 
 For details on which version of FontAwesome is used by each release of this addon, see the [Release Notes](https://github.com/FlowingCode/FontAwesomeIronIconset/releases)


### PR DESCRIPTION
Versions 2.x and 3.x use `iron-icon`, thus they will not be compatible with Vaadin 24. 
Version 4 should be compatible with Vaadin 24, but I haven't been able to test it so far, because of #56