### PR TITLE
chore: drop "Icon" from name and description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://jenkins.flowingcode.com/job/FontAwesomeIronIconset-23-addon/badge/icon)](https://jenkins.flowingcode.com/job/FontAwesomeIronIconset-23-addon)
 
-# Iron iconset based on FontAwesome
+# Iconset based on FontAwesome
 
 Integration of FontAwesome and vaadin-icon for Vaadin 10+
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,8 +5,8 @@
     <groupId>com.flowingcode.addons</groupId>
     <artifactId>font-awesome-iron-iconset</artifactId>
     <version>4.2.1-SNAPSHOT</version>
-    <name>FontAwesome Iron Iconset</name>
-    <description>Iron iconset based on FontAwesome</description>
+    <name>FontAwesome Iconset</name>
+    <description>Iconset based on FontAwesome</description>
     
     <properties>
         <vaadin.version>23.1.10</vaadin.version>


### PR DESCRIPTION
The first versions of this addon (up to 3.x) were based on `iron-iconset`, thus we had described it as an "iron iconset based on FontAwesome". In version 4 we moved from `iron-icon` to `vaadin-icon` (and `vaadin-iconset`), which makes "iron iconset" a misnomer.

While we should not rename the `artifactId`, we can avoid _iron_ references in README.md as well as POM `<name>` and `<description>` (which go into metadata).