### PR TITLE
fix: make javaFile path platform-agnostic

### DIFF
--- a/src/codegen/IconsetEnumCompiler.java
+++ b/src/codegen/IconsetEnumCompiler.java
@@ -40,6 +40,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -117,7 +118,8 @@ public class IconsetEnumCompiler {
     cfg.setStoreTokens(false);
     JavaParser parser = new JavaParser(cfg);
 
-    File javaFile = new File(sources, "com\\flowingcode\\vaadin\\addons\\fontawesome\\FontAwesome.java");
+    Path filePath = Path.of("com","flowingcode","vaadin","addons","fontawesome","FontAwesome.java");
+    File javaFile = new File(sources, filePath.toString());
     CompilationUnit cu = parser.parse(javaFile).getResult().get();
 
     TypeDeclaration typeDecl = cu.getPrimaryType().get();


### PR DESCRIPTION
Close #99

By going through `Path`, the path separators will depend on the actual OS the code is running on. I have tested this on macOS 14, but I don't have access to a Windows machine to double-check it still works there.