### PR TITLE
fix: register iconset when vaadin-iconset is defined

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ types.d.ts
 vite.generated.ts
 /src/main/dev-bundle
 /vite.config.ts
+/src/main/frontend

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
 		<dependency>
 			<groupId>com.flowingcode.vaadin.addons.demo</groupId>
 			<artifactId>commons-demo</artifactId>
-			<version>3.8.0</version>
+			<version>4.0.0</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -243,6 +243,9 @@
                     <supportedPackagings>
                         <supportedPackaging>jar</supportedPackaging>
                     </supportedPackagings>
+                    <systemProperties>
+                        <vaadin.frontend.hotdeploy>true</vaadin.frontend.hotdeploy>
+                    </systemProperties>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <url>https://www.flowingcode.com/en/open-source/</url>
     
     <properties>
-        <vaadin.version>24.0.3</vaadin.version>
+        <vaadin.version>24.3.10</vaadin.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <jetty.version>11.0.13</jetty.version>

--- a/src/codegen/modularize.xslt
+++ b/src/codegen/modularize.xslt
@@ -45,8 +45,9 @@ const template = document.createElement('template');
 template.innerHTML = `
 </xsl:text>
     <xsl:copy-of select="//fc-iconset/svg"/>
-<xsl:text>`;
+<xsl:text disable-output-escaping="yes">`;
 
+customElements.whenDefined('vaadin-iconset').then(Iconset=>{
 Iconset.register('</xsl:text
 ><xsl:value-of select="$family"/><xsl:text
 >', 1000, template);
@@ -58,7 +59,7 @@ const iconset = Iconset.getIconset('</xsl:text
 for (const name in aliases) {
     iconset._icons[name] = iconset._icons[aliases[name]];
 }
-
+});
 </xsl:text>
 </xsl:template>
 

--- a/src/main/javascript/font-awesome-iron-iconset/fab.js
+++ b/src/main/javascript/font-awesome-iron-iconset/fab.js
@@ -2884,6 +2884,7 @@ template.innerHTML = `
    </defs>
 </svg>`;
 
+customElements.whenDefined('vaadin-iconset').then(Iconset=>{
 Iconset.register('fab', 1000, template);
 
 const iconset = Iconset.getIconset('fab');
@@ -2891,4 +2892,4 @@ const iconset = Iconset.getIconset('fab');
 for (const name in aliases) {
     iconset._icons[name] = iconset._icons[aliases[name]];
 }
-
+});

--- a/src/main/javascript/font-awesome-iron-iconset/far.js
+++ b/src/main/javascript/font-awesome-iron-iconset/far.js
@@ -1119,6 +1119,7 @@ template.innerHTML = `
    </defs>
 </svg>`;
 
+customElements.whenDefined('vaadin-iconset').then(Iconset=>{
 Iconset.register('far', 1000, template);
 
 const iconset = Iconset.getIconset('far');
@@ -1126,4 +1127,4 @@ const iconset = Iconset.getIconset('far');
 for (const name in aliases) {
     iconset._icons[name] = iconset._icons[aliases[name]];
 }
-
+});

--- a/src/main/javascript/font-awesome-iron-iconset/fas.js
+++ b/src/main/javascript/font-awesome-iron-iconset/fas.js
@@ -8950,6 +8950,7 @@ template.innerHTML = `
    </defs>
 </svg>`;
 
+customElements.whenDefined('vaadin-iconset').then(Iconset=>{
 Iconset.register('fas', 1000, template);
 
 const iconset = Iconset.getIconset('fas');
@@ -8957,4 +8958,4 @@ const iconset = Iconset.getIconset('fas');
 for (const name in aliases) {
     iconset._icons[name] = iconset._icons[aliases[name]];
 }
-
+});


### PR DESCRIPTION
I'm not sure if this is a fix to #105, but certainly it doesn't harm.

```diff
+customElements.whenDefined('vaadin-iconset').then(Iconset=>{
Iconset.register('fas', 1000, template);

const iconset = Iconset.getIconset('fas');

for (const name in aliases) {
    iconset._icons[name] = iconset._icons[aliases[name]];
}
+});